### PR TITLE
fix: correct a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Below is an example of a batch render of every aquatic Minecraft mob using `/wik
 
 
 ### Namespace Entities
-To render entities given a select tag:
+To render entities given a select namespace:
 1. Type `/wikirender group entity namespace <namespace>` to render the namespace's entities
 2. Type `/wikirender group entity namespace <namespace> nbt <nbt>` to render the namespace's entities with NBT applied to each of them
 3. Type `/wikirender group entity namespace <namespace> nbt_filter <filter> <nbt>` to render the namespace's entities with NBT applied to each of them, but only rendering those with pass the filter check (see below)


### PR DESCRIPTION
correct a typo in README.md,
the correct is "To render entities given a select namespace", not "To render entities given a select tag".

<img width="1016" height="553" alt="image" src="https://github.com/user-attachments/assets/602a66fe-249f-4440-b4f2-2c86842841a7" />
