### PR TITLE
Fix README.md again

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Items can be rendered in three ways:
 1. Hold an item and type `/wikirender item`
 2. Hover over an item in your inventory and press the render hotkey (defaults to `h`)
 3. Type `/wikirender item id <item>`, where `<item>` is something like `minecraft:diamond`
-4. Type `/wikirender item texture <item>`, where `<item>` is a texture ID or base64 of a texture ID for a player head
+4. Type `/wikirender item texture <texture>`, where `<texture>` is a texture ID or base64 of a texture ID for a player head
 
 Below is an example of an enchanted compass made using `/wikirender item id minecraft:compass[minecraft:enchantment_glint_override=true]`:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Items can be rendered in three ways:
 1. Hold an item and type `/wikirender item`
 2. Hover over an item in your inventory and press the render hotkey (defaults to `h`)
 3. Type `/wikirender item id <item>`, where `<item>` is something like `minecraft:diamond`
-4. Type `/wikirender item texture <item>`, where `<texture>` is a texture ID or base64 of a texture ID for a player head
+4. Type `/wikirender item texture <item>`, where `<item>` is a texture ID or base64 of a texture ID for a player head
 
 Below is an example of an enchanted compass made using `/wikirender item id minecraft:compass[minecraft:enchantment_glint_override=true]`:
 


### PR DESCRIPTION
so i found another typo

in "Items" the command is "/wikirender item texture <item>" , but in following text is saying "<texture>"
after testing in game ,the correct command is "/wikirender item texture <texture>"
<img width="323" height="66" alt="image" src="https://github.com/user-attachments/assets/c176c806-4661-4539-94e6-7bd1d266cb3e" />
<img width="1100" height="318" alt="image" src="https://github.com/user-attachments/assets/41546f44-23d0-4f35-80f0-eaa25ae85171" />

