### PR TITLE
Fix readme.md again

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Items can be rendered in three ways:
 1. Hold an item and type `/wikirender item`
 2. Hover over an item in your inventory and press the render hotkey (defaults to `h`)
 3. Type `/wikirender item id <item>`, where `<item>` is something like `minecraft:diamond`
-4. Type `/wikirender item texture <item>`, where `<item>` is a texture ID or base64 of a texture ID for a player head
+4. Type `/wikirender item texture <texture>`, where `<texture>` is a texture ID or base64 of a texture ID for a player head
 
 Below is an example of an enchanted compass made using `/wikirender item id minecraft:compass[minecraft:enchantment_glint_override=true]`:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Below is an example of rendering a furnace using `/wikirender block minecraft:fu
 Item Tooltips can be rendered in similar ways to item renders:
 1. Hold an item and type `/wikirender tooltip`
 2. Hover over an item in your inventory and press the render tooltip hotkey (defaults to `k`)
-3. Type `/wikirender tooltip <tooltip>`, where `<item>` is something like `minecraft:diamond`
+3. Type `/wikirender tooltip <item>`, where `<item>` is something like `minecraft:diamond`
 
 Tooltips are rendered using per-pixel resolution scaling, defaulting at 4 image pixels per font pixel.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Items can be rendered in three ways:
 1. Hold an item and type `/wikirender item`
 2. Hover over an item in your inventory and press the render hotkey (defaults to `h`)
 3. Type `/wikirender item id <item>`, where `<item>` is something like `minecraft:diamond`
-4. Type `/wikirender item texture <item>`, where `<texture>` is a texture ID or base64 of a texture ID for a player head
+4. Type `/wikirender item texture <item>`, where `<item>` is a texture ID or base64 of a texture ID for a player head
 
 Below is an example of an enchanted compass made using `/wikirender item id minecraft:compass[minecraft:enchantment_glint_override=true]`:
 


### PR DESCRIPTION
the first typo:
in "Items" , the command is "/wikirender item texture \<item\>",
after testing in game, the right command is  "/wikirender item texture \<texture\>"
<img width="916" height="336" alt="image" src="https://github.com/user-attachments/assets/69ad1a87-b5d6-4a5f-8be6-aa87ed98c76f" />
<img width="305" height="78" alt="image" src="https://github.com/user-attachments/assets/8dcb8b5e-bd7a-4ba9-b9dc-c214bd6914d9" />
___
the second typo:
in "Item Tooltips" , the command is "/wikirender tooltip \<tooltip\>"
after testing in game, the right command is  "/wikirender tooltip \<item\>"
<img width="813" height="248" alt="image" src="https://github.com/user-attachments/assets/c6916b0c-2eec-4362-80ec-559dcbceea64" />
<img width="203" height="57" alt="image" src="https://github.com/user-attachments/assets/0a3bb8aa-c1b0-4c84-8904-8130e630abd3" />
