### PR TITLE
fix: correct horse sprite

### DIFF
--- a/src/main/java/com/pigicial/wikirenderer/render/entity/EntitySpriteModelVisibilityUtil.java
+++ b/src/main/java/com/pigicial/wikirenderer/render/entity/EntitySpriteModelVisibilityUtil.java
@@ -13,7 +13,8 @@ import java.util.function.Function;
 
 public class EntitySpriteModelVisibilityUtil {
 
-    public static void hideNonHeadParts(LivingEntityRenderer<?, ?, ?> livingEntityRenderer, List<Runnable> toggleCallbacks) {
+    public static void hideNonHeadParts(LivingEntityRenderer<?, ?, ?> livingEntityRenderer,
+                                        List<Runnable> toggleCallbacks) {
         EntityModel<?> model = livingEntityRenderer.getModel();
         EntitySpriteModelVisibilityUtil.hideNonHeadParts(model, toggleCallbacks);
     }
@@ -22,14 +23,14 @@ public class EntitySpriteModelVisibilityUtil {
         ModelPart root = model.root();
 
         Function<String, @Nullable ModelPart> partLookup = root.createPartLookup();
-        if (partLookup.apply("head") != null) {
-            EntitySpriteModelVisibilityUtil.hideNonHeadParts(toggleCallbacks, root, "head");
-        } else if (partLookup.apply("center_head") != null) {
-            // wither
-            EntitySpriteModelVisibilityUtil.hideNonHeadParts(toggleCallbacks, root, "center_head");
-        } else if (partLookup.apply("body") != null) {
-            EntitySpriteModelVisibilityUtil.hideNonHeadParts(toggleCallbacks, root, "body");
-        }
+
+        String[] partsToFind = {"head_parts" /* Horse */, "head", "center_head" /* Wither */, "body"};
+
+        for (String part : partsToFind)
+            if (partLookup.apply(part) != null) {
+                EntitySpriteModelVisibilityUtil.hideNonHeadParts(toggleCallbacks, root, part);
+                break;
+            }
     }
 
     public static void hideNonHeadParts(List<Runnable> toggleCallbacks, ModelPart part, String headType) {


### PR DESCRIPTION
This PR correctly handles the sprites for entities that implement `AbstractEquineModel` (or any other models that use `head_parts` as a model part name). This also refactors that code block to be a bit more modular.

Example renders:

<img width="201" height="272" alt="horse_1_" src="https://github.com/user-attachments/assets/558ea170-bf55-40d8-b2e6-170959f0d0db" />
<img width="197" height="258" alt="skeleton_horse" src="https://github.com/user-attachments/assets/1a43d1da-06f0-4196-be34-27d5006384c4" />
<img width="212" height="288" alt="zombie_horse" src="https://github.com/user-attachments/assets/48e757af-bb1f-492a-9516-ad86d6347348" />