### PR TITLE
feat(compat): add optional REI search field focus detection to block inventory rendering commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ repositories {
             includeGroup("maven.modrinth")
         }
     }
+    maven { url "https://maven.shedaniel.me/"}
     mavenLocal()
 
     maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
@@ -53,6 +54,7 @@ dependencies {
 
     modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:${project.devauth_version}")
     compileOnly "maven.modrinth:iris:${project.iris_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
 }
 
 def gifskiVersion = project.gifski_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ exo_version=0.1.5+1.19
 owo_version=0.13.0+1.21.11
 iris_version=1.10.5+1.21.11-fabric
 devauth_version=1.2.2
+rei_version=21.11.814
 
 # Gifski
 gifski_version=1.34.0

--- a/src/main/java/com/pigicial/wikirenderer/WikiRendererKeybinds.java
+++ b/src/main/java/com/pigicial/wikirenderer/WikiRendererKeybinds.java
@@ -2,6 +2,7 @@ package com.pigicial.wikirenderer;
 
 import com.pigicial.wikirenderer.command.subcommands.RenderBlockSubCommand;
 import com.pigicial.wikirenderer.command.subcommands.RenderEntitySubCommand;
+import com.pigicial.wikirenderer.compat.REISearchFocus;
 import com.pigicial.wikirenderer.mixin.access.AbstractContainerScreenAccessor;
 import com.pigicial.wikirenderer.mixin.access.CreativeModeInventoryScreenAccessor;
 import com.pigicial.wikirenderer.render.area.AreaSelectionHelper;
@@ -15,6 +16,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
@@ -42,6 +44,8 @@ public class WikiRendererKeybinds {
     public static final KeyMapping KEYBIND_RENDER_TARGETED_BLOCK = new KeyMapping("key.wikirenderer.render_targeted_block", GLFW.GLFW_KEY_L, CATEGORY);
     public static final KeyMapping KEYBIND_RENDER_INVENTORY = new KeyMapping("key.wikirenderer.render_inventory", GLFW.GLFW_KEY_SEMICOLON, CATEGORY);
     public static final KeyMapping KEYBIND_BATCH_RENDER_INVENTORY_ITEMS = new KeyMapping("key.wikirenderer.batch_render_inventory", GLFW.GLFW_KEY_K, CATEGORY);
+
+    private static final boolean REI_LOADED = FabricLoader.getInstance().isModLoaded("roughlyenoughitems");
 
     public static void registerKeyBinds() {
         KeyBindingHelper.registerKeyBinding(KEYBIND_SELECT_AREA);
@@ -82,6 +86,8 @@ public class WikiRendererKeybinds {
         });
 
         ScreenEvents.AFTER_INIT.register((client, screen, width, height) -> ScreenKeyboardEvents.afterKeyPress(screen).register((s, key) -> {
+            if (isTypingInAnyTextField(s)) return;
+
             if (KEYBIND_RENDER_HOVERED_ITEM_OR_VIEWED_ENTITY.matches(key)) {
                 ItemStack hoveredSlot = getHoveredSlot(client);
                 if (hoveredSlot != null) {
@@ -110,6 +116,12 @@ public class WikiRendererKeybinds {
                 }
             }
         }));
+    }
+
+    private static boolean isTypingInAnyTextField(Screen screen) {
+        if (screen.getFocused() instanceof EditBox) return true;
+        if (REI_LOADED && REISearchFocus.isSearchFieldFocused()) return true;
+        return false;
     }
 
     @Nullable

--- a/src/main/java/com/pigicial/wikirenderer/compat/REISearchFocus.java
+++ b/src/main/java/com/pigicial/wikirenderer/compat/REISearchFocus.java
@@ -1,0 +1,61 @@
+package com.pigicial.wikirenderer.compat;
+
+import me.shedaniel.rei.api.client.REIRuntime;
+import me.shedaniel.rei.api.client.gui.widgets.TextField;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+
+public class REISearchFocus {
+
+    private static Method cachedIsFocused = null;
+    private static boolean initialized = false;
+
+    // isVisible and hasBorder are stable unobfuscated names on TextFieldWidget.
+    // The only remaining boolean no-arg method is isFocused(), obfuscated by REI
+    // (see shedaniel/RoughlyEnoughItems#1818).
+    private static final Set<String> EXCLUDED = Set.of("isVisible", "hasBorder");
+
+    public static boolean isSearchFieldFocused() {
+        try {
+            REIRuntime runtime = REIRuntime.getInstance();
+            if (runtime == null) return false;
+
+            TextField searchField = runtime.getSearchTextField();
+            if (searchField == null) return false;
+
+            if (!initialized) {
+                initialized = true;
+                cachedIsFocused = resolveIsFocused(searchField.getClass());
+            }
+
+            return cachedIsFocused != null && (boolean) cachedIsFocused.invoke(searchField);
+
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Walks the class hierarchy to find TextFieldWidget, then returns the single
+     * boolean no-arg method that is neither isVisible nor hasBorder — that is
+     * isFocused() regardless of its obfuscated runtime name.
+     */
+    private static Method resolveIsFocused(Class<?> clazz) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            if (current.getSimpleName().contains("TextFieldWidget")) {
+                return Arrays.stream(current.getDeclaredMethods())
+                    .filter(m -> m.getParameterCount() == 0)
+                    .filter(m -> m.getReturnType() == boolean.class)
+                    .filter(m -> !EXCLUDED.contains(m.getName()))
+                    .findFirst()
+                    .map(m -> { m.setAccessible(true); return m; })
+                    .orElse(null);
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Issue

Keybinds registered via `ScreenKeyboardEvents.afterKeyPress` were firing while typing in the REI search bar, consuming the bound key and making it unavailable for search input.

## Solution

Add `REISearchFocus`, an isolated compat class that checks whether REI's `OverlaySearchField` is focused before allowing screen keybinds to execute. All keybind handling is gated behind a `REI_LOADED` flag (via `FabricLoader`) so the mod remains fully functional without REI.

REI is added as `modCompileOnly`: it is present at compile time but not bundled in the jar, and not required at runtime.

## The `isFocused()` obfuscation problem

The straightforward approach — calling `REIRuntime.getInstance().getSearchTextField().isFocused()` — does not work because REI accidentally obfuscated `isFocused()` on the `TextField` interface at the bytecode level. This is a known upstream issue: [shedaniel/RoughlyEnoughItems#1818](https://github.com/shedaniel/RoughlyEnoughItems/issues/1818).

## How the correct method is resolved

At runtime, `getSearchTextField()` returns an `OverlaySearchField` instance. Inspecting its class hierarchy via reflection reveals that `TextFieldWidget` (its parent) declares exactly three boolean no-arg methods:

- `isVisible`
- `hasBorder`
- `method_25370` ← obfuscated name of `isFocused()` under Mojang mappings

`isVisible` and `hasBorder` are stable unobfuscated names. By excluding them, the single remaining method is `isFocused()` regardless of its obfuscated runtime name. This name may change across Minecraft versions, but the exclusion logic remains correct as long as REI does not add a fourth boolean no-arg method to `TextFieldWidget`.

The resolved `Method` is cached after the first call to avoid repeated reflection overhead.

## Notes

⚠️ The mod version number has not been bumped in this PR, as I am not familiar with this project's versioning conventions. Please update it as appropriate before merging.