### PR TITLE
Add Head texture_id PNG Metadata

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,8 @@ entity_culling_version=NaRJu6ah
 
 devauth_version=1.2.2
 
-litematica_version=26.2:0.28.0
-malilib_version=26.2:0.29.0
+litematica_version=26.2:0.28.3
+malilib_version=26.2:0.29.3
 
 # Gifski
 gifski_version=1.34.0

--- a/src/main/java/com/pigicial/wikirenderer/render/Renderable.java
+++ b/src/main/java/com/pigicial/wikirenderer/render/Renderable.java
@@ -11,6 +11,8 @@ import net.minecraft.client.input.MouseButtonEvent;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4fStack;
 
+import java.util.Map;
+
 public interface Renderable<P extends PropertyBundle> {
 
     Renderable<PropertyBundle> EMPTY = new EmptyRenderable();
@@ -76,6 +78,10 @@ public interface Renderable<P extends PropertyBundle> {
 
     default int optionallyOverrideExportHeight(int height) {
         return height;
+    }
+
+    default Map<String, String> getPngTextMetadata() {
+        return Map.of();
     }
 
     default void onAnimationStart() {}

--- a/src/main/java/com/pigicial/wikirenderer/render/batch/BatchRenderable.java
+++ b/src/main/java/com/pigicial/wikirenderer/render/batch/BatchRenderable.java
@@ -250,4 +250,9 @@ public class BatchRenderable<R extends Renderable<?>> implements Renderable<Batc
             return false;
         }
     }
+
+    @Override
+    public Map<String, String> getPngTextMetadata() {
+        return this.currentDelegate.getPngTextMetadata();
+    }
 }

--- a/src/main/java/com/pigicial/wikirenderer/render/export/FileIO.java
+++ b/src/main/java/com/pigicial/wikirenderer/render/export/FileIO.java
@@ -8,12 +8,24 @@ import com.pigicial.wikirenderer.util.Translate;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Util;
+import org.w3c.dom.NodeList;
 
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.metadata.IIOMetadataNode;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,6 +36,10 @@ public class FileIO {
     private static final AtomicInteger TASK_COUNT = new AtomicInteger(0);
 
     public static CompletableFuture<File> saveImage(NativeImage image, ExportPathSpec path) {
+        return saveImage(image, path, Map.of());
+    }
+
+    public static CompletableFuture<File> saveImage(NativeImage image, ExportPathSpec path, Map<String, String> pngTextMetadata) {
         CompletableFuture<File> future = new CompletableFuture<>();
 
         TASK_COUNT.incrementAndGet();
@@ -38,6 +54,9 @@ public class FileIO {
 
                 try {
                     image.writeToFile(imageFile);
+                    if (!pngTextMetadata.isEmpty()) {
+                        writePngTextMetadata(imageFile, pngTextMetadata);
+                    }
                     WikiRenderer.LOGGER.info("Image {} saved", imageFile.getAbsolutePath());
                     future.complete(imageFile);
                 } catch (IOException e) {
@@ -50,6 +69,70 @@ public class FileIO {
         }
 
         return future;
+    }
+
+    private static void writePngTextMetadata(File imageFile, Map<String, String> pngTextMetadata) throws IOException {
+        BufferedImage image = ImageIO.read(imageFile);
+        if (image == null) {
+            throw new IOException("Could not decode png image to append metadata: " + imageFile.getAbsolutePath());
+        }
+
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("png");
+        if (!writers.hasNext()) {
+            throw new IOException("No PNG ImageWriter available");
+        }
+
+        ImageWriter writer = writers.next();
+        try (ImageOutputStream output = ImageIO.createImageOutputStream(imageFile)) {
+            if (output == null) {
+                throw new IOException("Could not create output stream for image metadata: " + imageFile.getAbsolutePath());
+            }
+
+            writer.setOutput(output);
+            ImageWriteParam params = writer.getDefaultWriteParam();
+
+            ImageTypeSpecifier typeSpecifier = ImageTypeSpecifier.createFromRenderedImage(image);
+            IIOMetadata metadata = writer.getDefaultImageMetadata(typeSpecifier, params);
+            String nativeFormat = metadata.getNativeMetadataFormatName();
+
+            IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(nativeFormat);
+            IIOMetadataNode textNode = getOrCreateChild(root, "tEXt");
+
+            for (Map.Entry<String, String> entry : pngTextMetadata.entrySet()) {
+                removeExistingTextEntry(textNode, entry.getKey());
+
+                IIOMetadataNode textEntryNode = new IIOMetadataNode("tEXtEntry");
+                textEntryNode.setAttribute("keyword", entry.getKey());
+                textEntryNode.setAttribute("value", entry.getValue());
+                textNode.appendChild(textEntryNode);
+            }
+
+            metadata.mergeTree(nativeFormat, root);
+            writer.write(null, new IIOImage(image, null, metadata), params);
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    private static IIOMetadataNode getOrCreateChild(IIOMetadataNode root, String childName) {
+        NodeList children = root.getElementsByTagName(childName);
+        if (children.getLength() > 0) {
+            return (IIOMetadataNode) children.item(0);
+        }
+
+        IIOMetadataNode created = new IIOMetadataNode(childName);
+        root.appendChild(created);
+        return created;
+    }
+
+    private static void removeExistingTextEntry(IIOMetadataNode textNode, String keyword) {
+        NodeList textEntries = textNode.getElementsByTagName("tEXtEntry");
+        for (int i = textEntries.getLength() - 1; i >= 0; i--) {
+            IIOMetadataNode node = (IIOMetadataNode) textEntries.item(i);
+            if (keyword.equals(node.getAttribute("keyword"))) {
+                textNode.removeChild(node);
+            }
+        }
     }
 
     public static CompletableFuture<File> saveText(String text, ExportPathSpec path, String extension) {

--- a/src/main/java/com/pigicial/wikirenderer/render/item/ItemRenderable.java
+++ b/src/main/java/com/pigicial/wikirenderer/render/item/ItemRenderable.java
@@ -13,6 +13,7 @@ import com.pigicial.wikirenderer.textures.TextureDataProvider;
 import com.pigicial.wikirenderer.util.AnimationTimingUtil;
 import com.pigicial.wikirenderer.util.ItemNameUtil;
 import net.minecraft.client.Minecraft;
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
@@ -130,5 +131,25 @@ public class ItemRenderable extends ItemBasedRenderable<ItemRenderablePropertyBu
         List<Integer> animationTimings = new LinkedList<>();
         AnimationTimingUtil.scanTicksToFullyAnimateItem(stack, animationTimings);
         return List.of(animationTimings);
+    }
+
+    @Override
+    public Map<String, String> getPngTextMetadata() {
+        TextureData headTextureData = PlayerTextureUtils.getTextureDataFromPlayerHead(this.stack);
+        if (headTextureData == null) {
+            return Map.of();
+        }
+
+        MinecraftProfileTexture skinTexture = headTextureData.payload().textures().get(MinecraftProfileTexture.Type.SKIN);
+        if (skinTexture == null) {
+            return Map.of();
+        }
+
+        String textureId = skinTexture.getHash();
+        if (textureId == null || textureId.isBlank()) {
+            return Map.of();
+        }
+
+        return Map.of("texture_id", textureId);
     }
 }

--- a/src/main/java/com/pigicial/wikirenderer/screen/RenderScreen.java
+++ b/src/main/java/com/pigicial/wikirenderer/screen/RenderScreen.java
@@ -698,7 +698,7 @@ public class RenderScreen extends BaseOwoScreen<FlowLayout> {
         }
 
         RenderableDispatcher.drawIntoImage(this, this.renderable, tickDelta, this.getTimeSinceCreationMs(), renderable.getExportResolution(), renderable.shouldCrop(), dataConsumer)
-                .thenCompose(img -> FileIO.saveImage(img, exportPath).whenComplete((_, _) -> img.close()))
+            .thenCompose(img -> FileIO.saveImage(img, exportPath, this.renderable.getPngTextMetadata()).whenComplete((_, _) -> img.close()))
                 .whenComplete((imageFile, throwable) -> {
                     capturing = false;
                     if (throwable != null) {


### PR DESCRIPTION
# Add Head `texture_id` PNG Metadata (Single + Batch Renders)

Tried to play with tEXt metadata fields, and thought about storing the head's texture ID inside a custom field, allowing us to retrieve the texture_id even if it wasn't copied from the RenderScreen.

## Summary

Adds PNG text metadata support to exports and writes a `texture_id` entry when rendering player heads.

The feature works on:
- Single item renders
- Batch item renders (on the current item)
> Note: `tEXt` is not included in animation batch PNG frames

Non-head item renders remain unchanged.

## Wiki Limitations

Custom `tEXt` fields aren't shown on the wiki, meaning an external tool is needed to retrieve the info.

It can however be useful, in my opinion, to store this kind of information inside the image itself, to help find the ID after uploading non-reproducible renders (e.g. limited exclusive skins, legacy items, etc.).

## Improvements

Since metadata fields are handled as a map, we can imagine adding more `tEXt` fields in the future, for the internal skyblock item id for example...

> To test that the `tEXt` field is created, I'm using exiftool

```csh
C:\Users\John Doe\Desktop>exiftool "Empty Storm Bottle.png"
ExifTool Version Number         : 13.59
File Name                       : Empty Storm Bottle.png
Directory                       : .
File Size                       : 9.2 kB
File Modification Date/Time     : 2026:07:10 23:15:04+02:00
File Access Date/Time           : 2026:07:10 23:15:29+02:00
File Creation Date/Time         : 2026:07:10 23:15:04+02:00
File Permissions                : -rw-rw-rw-
File Type                       : PNG
File Type Extension             : png
MIME Type                       : image/png
Image Width                     : 300
Image Height                    : 300
Bit Depth                       : 8
Color Type                      : RGB with Alpha
Compression                     : Deflate/Inflate
Filter                          : Adaptive
Interlace                       : Noninterlaced
Texture id                      : 65b53a16cc9574fbcb1c01c2433e7b99b543b70b0d93475ca441b0dc54bb118e
Image Size                      : 300x300
Megapixels                      : 0.090
```

## Note

This PR is mostly meant as a proposal to discuss the idea of adding this metadata, no worries if it doesn't get merged, you can close it if it's not relevant to the project :)

⚠️I had to upgrade Litematica and MaLiLib, as the target versions were no longer available on the maven repos.